### PR TITLE
fix: Add protection to the API request (XY Finance)

### DIFF
--- a/apps/workshop/projects/XYFinance/modules/veXY.ts
+++ b/apps/workshop/projects/XYFinance/modules/veXY.ts
@@ -79,7 +79,7 @@ export function veXY(chain: SupportedChain): ModuleDefinitionInterface {
       if (!pool.supplied) return [];
 
       const veXYContract = new ethcall.Contract(veXY.veXY, veXYAbi);
-      const [[locked, end]] = await ethcallProvider.all<typeof BigNumber[][]>([
+      const [[locked, end]] = await ethcallProvider.all<(typeof BigNumber)[][]>([
         veXYContract.locked(user),
       ]);
       const delimiter = new BigNumber(10).pow(18);

--- a/apps/workshop/projects/XYFinance/modules/veXY.ts
+++ b/apps/workshop/projects/XYFinance/modules/veXY.ts
@@ -46,9 +46,12 @@ export function veXY(chain: SupportedChain): ModuleDefinitionInterface {
       const tvl = (Number(locked.toString()) / 10 ** 18) * (token?.price || 0);
 
       const BASE_API_URL = 'https://api.xy.finance';
-      const resp = await axios.get(`${BASE_API_URL}/ypool/vexy/lockWeekApy`);
-      const weekAPY = resp.data.apy / 100;
-      const apr = weekAPY * 104;
+      let apr = 0;
+      try {
+        const resp = await axios.get(`${BASE_API_URL}/ypool/vexy/lockWeekApy`);
+        const weekAPY = resp.data.apy / 100;
+        apr = weekAPY * 104;
+      } catch {}
 
       return [
         {


### PR DESCRIPTION
### What's wrong?
The module `veXY` would crash if the API request to the server does not work as expected.

### How do I fix it?
Add a try catch to the API request to protect the module from crashing entirely.
If the API request fail, put `0` as the default APR for the pool.